### PR TITLE
Streamchild syntax fixes

### DIFF
--- a/api/schema.py
+++ b/api/schema.py
@@ -27,24 +27,24 @@ class ArticleNode(DjangoObjectType):
         fields = ('id', 'title', 'date', 'intro')
 
     def resolve_body(self, info):
-      """
-      self.body seems to be an empty list, but from frontend test, definitely contains data
-      This resolver (union type with this block case) below _should_ work, if we give it some
-      data to return
+        """
+        self.body seems to be an empty list, but from frontend test, definitely contains data
+        This resolver (union type with this block case) below _should_ work, if we give it some
+        data to return
 
-      self should be (is) a BlogPage instance. The other fields exist.
-      I'm expecting all the data from the db record should be available here, but this is where
-      my knowledge of Django/Wagtail fails me.
+        self should be (is) a BlogPage instance. The other fields exist.
+        I'm expecting all the data from the db record should be available here, but this is where
+        my knowledge of Django/Wagtail fails me.
 
-      Some examples use self.body.stream_data, however this is deprecated in favour of just using
-      self.body. I've tried both, they're both an empty StreamField list.
-      """
+        Some examples use self.body.stream_data, however this is deprecated in favour of just using
+        self.body. I've tried both, they're both an empty StreamField list.
+        """
         repr_body = []
         for block in self.body:
-            block_type = block.get('type')
-            value = block.get('value')
+            block_type = block.block_type
+            value = block.value
             if block_type == 'paragraph':
-                repr_body.append(ParagraphBlock(value=value))
+                repr_body.append(ParagraphBlock(value=value.source))
             elif block_type == 'heading':
                 repr_body.append(HeadingBlock(value=value))
         return repr_body


### PR DESCRIPTION
The internals of streamfields are a tricky thing. The `StreamValue` is what can be treated as a dict, but the `StreamChild` (the iteration of self.body) is an object that contains the block metadata, and contains the `StreamValue`.